### PR TITLE
Support for MegaCoreX compatible targets

### DIFF
--- a/boards/ATmega1608.json
+++ b/boards/ATmega1608.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "core": "MegaCoreX",
+    "extra_flags": "-DARDUINO_AVR_ATMEGA1608",
+    "f_cpu": "16000000L",
+    "mcu": "atmega1608",
+    "variant": "32pin-standard"
+  },
+  "hardware": {
+    "oscillator": "internal",
+    "uart": "no_bootloader"
+  },
+  "bootloader":{
+    "led_pin": "A7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega1608",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 16384,
+    "protocol": "jtag2updi",
+    "require_upload_port": true,
+    "speed": 115200,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATMEGA1608",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega1609.json
+++ b/boards/ATmega1609.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "core": "MegaCoreX",
+    "extra_flags": "-DARDUINO_AVR_ATMEGA1609",
+    "f_cpu": "16000000L",
+    "mcu": "atmega1609",
+    "variant": "48pin-standard"
+  },
+  "hardware": {
+    "oscillator": "internal",
+    "uart": "no_bootloader"
+  },
+  "bootloader":{
+    "led_pin": "A7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega1609",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 16384,
+    "protocol": "jtag2updi",
+    "require_upload_port": true,
+    "speed": 115200,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATMEGA1609",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega3208.json
+++ b/boards/ATmega3208.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "core": "MegaCoreX",
+    "extra_flags": "-DARDUINO_AVR_ATMEGA3208",
+    "f_cpu": "16000000L",
+    "mcu": "atmega3208",
+    "variant": "32pin-standard"
+  },
+  "hardware": {
+    "oscillator": "internal",
+    "uart": "no_bootloader"
+  },
+  "bootloader":{
+    "led_pin": "A7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega3208",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 32768,
+    "protocol": "jtag2updi",
+    "require_upload_port": true,
+    "speed": 115200,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATMEGA3208",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega3209.json
+++ b/boards/ATmega3209.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "core": "MegaCoreX",
+    "extra_flags": "-DARDUINO_AVR_ATMEGA3209",
+    "f_cpu": "16000000L",
+    "mcu": "atmega3209",
+    "variant": "48pin-standard"
+  },
+  "hardware": {
+    "oscillator": "internal",
+    "uart": "no_bootloader"
+  },
+  "bootloader":{
+    "led_pin": "A7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega3209",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 32768,
+    "protocol": "jtag2updi",
+    "require_upload_port": true,
+    "speed": 115200,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATMEGA3209",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega4808.json
+++ b/boards/ATmega4808.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "core": "MegaCoreX",
+    "extra_flags": "-DARDUINO_AVR_ATMEGA4808",
+    "f_cpu": "16000000L",
+    "mcu": "atmega4808",
+    "variant": "32pin-standard"
+  },
+  "hardware": {
+    "oscillator": "internal",
+    "uart": "no_bootloader"
+  },
+  "bootloader":{
+    "led_pin": "A7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega4808",
+  "upload": {
+    "maximum_ram_size": 6144,
+    "maximum_size": 49152,
+    "protocol": "jtag2updi",
+    "require_upload_port": true,
+    "speed": 115200,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATMEGA4808",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega4809.json
+++ b/boards/ATmega4809.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "core": "MegaCoreX",
+    "extra_flags": "-DARDUINO_AVR_ATMEGA4809",
+    "f_cpu": "16000000L",
+    "mcu": "atmega4809",
+    "variant": "48pin-standard"
+  },
+  "hardware": {
+    "oscillator": "internal",
+    "uart": "no_bootloader"
+  },
+  "bootloader":{
+    "led_pin": "A7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega4809",
+  "upload": {
+    "maximum_ram_size": 6144,
+    "maximum_size": 49152,
+    "protocol": "jtag2updi",
+    "require_upload_port": true,
+    "speed": 115200,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATMEGA4809",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega808.json
+++ b/boards/ATmega808.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "core": "MegaCoreX",
+    "extra_flags": "-DARDUINO_AVR_ATMEGA808",
+    "f_cpu": "16000000L",
+    "mcu": "atmega808",
+    "variant": "32pin-standard"
+  },
+  "hardware": {
+    "oscillator": "internal",
+    "uart": "no_bootloader"
+  },
+  "bootloader":{
+    "led_pin": "A7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega808",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 8192,
+    "protocol": "jtag2updi",
+    "require_upload_port": true,
+    "speed": 115200,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATMEGA808",
+  "vendor": "Microchip"
+}

--- a/boards/ATmega809.json
+++ b/boards/ATmega809.json
@@ -1,0 +1,31 @@
+{
+  "build": {
+    "core": "MegaCoreX",
+    "extra_flags": "-DARDUINO_AVR_ATMEGA809",
+    "f_cpu": "16000000L",
+    "mcu": "atmega809",
+    "variant": "48pin-standard"
+  },
+  "hardware": {
+    "oscillator": "internal",
+    "uart": "no_bootloader"
+  },
+  "bootloader":{
+    "led_pin": "A7"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATmega809",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 8192,
+    "protocol": "jtag2updi",
+    "require_upload_port": true,
+    "speed": 115200,
+    "use_1200bps_touch": true,
+    "wait_for_upload_port": true
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATMEGA809",
+  "vendor": "Microchip"
+}


### PR DESCRIPTION
This is the initial work that's needed to get full [MegaCoreX](https://github.com/MCUdude/MegaCoreX) support to PlatformIO.
Hopefully, this will lead to a collaboration with @valeros so #2 can be resolved.

Is there anything I can do in order to speed this up?