### PR TITLE
Add manifest files for all tinyAVR-0 and tinyAVR-1 chips

### DIFF
--- a/boards/ATtiny1604.json
+++ b/boards/ATtiny1604.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERA0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny1604",
+    "variant": "txy4"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny1604",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 16384,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY1604",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny1606.json
+++ b/boards/ATtiny1606.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERA0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny1606",
+    "variant": "txy6"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny1606",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 16384,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY1606",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny1607.json
+++ b/boards/ATtiny1607.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERA0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny1607",
+    "variant": "txy7"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny1607",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 16384,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY1607",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny1614.json
+++ b/boards/ATtiny1614.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny1614",
+    "variant": "txy4"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny1614",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 16384,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY1614",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny1616.json
+++ b/boards/ATtiny1616.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny1616",
+    "variant": "txy6"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny1616",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 16384,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY1616",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny1617.json
+++ b/boards/ATtiny1617.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny1617",
+    "variant": "txy7"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny1617",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 16384,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY1617",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny202.json
+++ b/boards/ATtiny202.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy2 -DMILLIS_USE_TIMERA0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny202",
+    "variant": "txy2"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny202",
+  "upload": {
+    "maximum_ram_size": 128,
+    "maximum_size": 2048,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY202",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny204.json
+++ b/boards/ATtiny204.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERA0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny204",
+    "variant": "txy4"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny204",
+  "upload": {
+    "maximum_ram_size": 128,
+    "maximum_size": 2048,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY204",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny212.json
+++ b/boards/ATtiny212.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy2 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny212",
+    "variant": "txy2"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny212",
+  "upload": {
+    "maximum_ram_size": 128,
+    "maximum_size": 2048,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY212",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny214.json
+++ b/boards/ATtiny214.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny214",
+    "variant": "txy4"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny214",
+  "upload": {
+    "maximum_ram_size": 128,
+    "maximum_size": 2048,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY214",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny3216.json
+++ b/boards/ATtiny3216.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny3216",
+    "variant": "txy6"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny3216",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 32768,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY3216",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny3217.json
+++ b/boards/ATtiny3217.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny3217",
+    "variant": "txy7"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny3217",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 32768,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY3217",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny402.json
+++ b/boards/ATtiny402.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy2 -DMILLIS_USE_TIMERA0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny402",
+    "variant": "txy2"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny402",
+  "upload": {
+    "maximum_ram_size": 256,
+    "maximum_size": 4096,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY402",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny404.json
+++ b/boards/ATtiny404.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERA0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny404",
+    "variant": "txy4"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny404",
+  "upload": {
+    "maximum_ram_size": 256,
+    "maximum_size": 4096,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY404",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny406.json
+++ b/boards/ATtiny406.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERA0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny406",
+    "variant": "txy6"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny406",
+  "upload": {
+    "maximum_ram_size": 256,
+    "maximum_size": 4096,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY406",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny412.json
+++ b/boards/ATtiny412.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy2 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny412",
+    "variant": "txy2"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny412",
+  "upload": {
+    "maximum_ram_size": 256,
+    "maximum_size": 4096,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY412",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny414.json
+++ b/boards/ATtiny414.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny414",
+    "variant": "txy4"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny414",
+  "upload": {
+    "maximum_ram_size": 256,
+    "maximum_size": 4096,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY414",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny416.json
+++ b/boards/ATtiny416.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny416",
+    "variant": "txy6"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny416",
+  "upload": {
+    "maximum_ram_size": 256,
+    "maximum_size": 4096,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY416",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny417.json
+++ b/boards/ATtiny417.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny417",
+    "variant": "txy7"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny417",
+  "upload": {
+    "maximum_ram_size": 256,
+    "maximum_size": 4096,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY417",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny804.json
+++ b/boards/ATtiny804.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERA0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny804",
+    "variant": "txy4"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny804",
+  "upload": {
+    "maximum_ram_size": 512,
+    "maximum_size": 8192,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY804",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny806.json
+++ b/boards/ATtiny806.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERA0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny806",
+    "variant": "txy6"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny806",
+  "upload": {
+    "maximum_ram_size": 512,
+    "maximum_size": 8192,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY806",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny807.json
+++ b/boards/ATtiny807.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERA0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny807",
+    "variant": "txy7"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny807",
+  "upload": {
+    "maximum_ram_size": 512,
+    "maximum_size": 8192,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY807",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny814.json
+++ b/boards/ATtiny814.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny814",
+    "variant": "txy4"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny814",
+  "upload": {
+    "maximum_ram_size": 512,
+    "maximum_size": 8192,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY814",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny816.json
+++ b/boards/ATtiny816.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny816",
+    "variant": "txy6"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny816",
+  "upload": {
+    "maximum_ram_size": 512,
+    "maximum_size": 8192,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY816",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny817.json
+++ b/boards/ATtiny817.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megaTinyCore",
+    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny817",
+    "variant": "txy7"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny817",
+  "upload": {
+    "maximum_ram_size": 512,
+    "maximum_size": 8192,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY817",
+  "vendor": "Microchip"
+}


### PR DESCRIPTION
Supported by @SpenceKonde's [megaTinyCore](https://github.com/SpenceKonde/megaTinyCore).
FYI I can see if I can figure ut all the fuse settings for these targets, so we can get the fuse calculation script working for these as well.

https://github.com/platformio/platform-atmelavr/issues/83 related.