### PR TITLE
Fix path escaping for AVRDude config file

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -74,7 +74,7 @@ env.Replace(
     UPLOADER="avrdude",
     UPLOADERFLAGS=[
         "-p", "$BOARD_MCU", "-C",
-        '"%s"' % join(env.PioPlatform().get_package_dir(
+        join(env.PioPlatform().get_package_dir(
             "tool-avrdude-megaavr") or "", "avrdude.conf"),
         "-c", "$UPLOAD_PROTOCOL"
     ],


### PR DESCRIPTION
As noted in https://community.platformio.org/t/uploading-to-arduino-nano-every-avrdude-cant-open-config-file/17215, when the path to the config file contains a space, e.g. when the username has a space, AVRDude can't read that path anymore. Just use the full string as a normal argument without enclosing it in quotes.

The code in `platform-atmelavr` is of the same type, but this one here is broken.

https://github.com/platformio/platform-atmelavr/blob/a7ca0e1c30a2dbd4ee078f8f4ee5ddd68c78cc91/builder/main.py#L197-L211