### PR TITLE
Fix ARDUINO_AVR macros

### DIFF
--- a/boards/ATmega1608.json
+++ b/boards/ATmega1608.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "MegaCoreX",
-    "extra_flags": "-DARDUINO_AVR_ATMEGA1608",
+    "extra_flags": "-DARDUINO_AVR_ATmega1608",
     "f_cpu": "16000000L",
     "mcu": "atmega1608",
     "variant": "32pin-standard"

--- a/boards/ATmega1609.json
+++ b/boards/ATmega1609.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "MegaCoreX",
-    "extra_flags": "-DARDUINO_AVR_ATMEGA1609",
+    "extra_flags": "-DARDUINO_AVR_ATmega1609",
     "f_cpu": "16000000L",
     "mcu": "atmega1609",
     "variant": "48pin-standard"

--- a/boards/ATmega3208.json
+++ b/boards/ATmega3208.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "MegaCoreX",
-    "extra_flags": "-DARDUINO_AVR_ATMEGA3208",
+    "extra_flags": "-DARDUINO_AVR_ATmega3208",
     "f_cpu": "16000000L",
     "mcu": "atmega3208",
     "variant": "32pin-standard"

--- a/boards/ATmega3209.json
+++ b/boards/ATmega3209.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "MegaCoreX",
-    "extra_flags": "-DARDUINO_AVR_ATMEGA3209",
+    "extra_flags": "-DARDUINO_AVR_ATmega3209",
     "f_cpu": "16000000L",
     "mcu": "atmega3209",
     "variant": "48pin-standard"

--- a/boards/ATmega4808.json
+++ b/boards/ATmega4808.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "MegaCoreX",
-    "extra_flags": "-DARDUINO_AVR_ATMEGA4808",
+    "extra_flags": "-DARDUINO_AVR_ATmega4808",
     "f_cpu": "16000000L",
     "mcu": "atmega4808",
     "variant": "32pin-standard"

--- a/boards/ATmega4809.json
+++ b/boards/ATmega4809.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "MegaCoreX",
-    "extra_flags": "-DARDUINO_AVR_ATMEGA4809",
+    "extra_flags": "-DARDUINO_AVR_ATmega4809",
     "f_cpu": "16000000L",
     "mcu": "atmega4809",
     "variant": "48pin-standard"

--- a/boards/ATmega808.json
+++ b/boards/ATmega808.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "MegaCoreX",
-    "extra_flags": "-DARDUINO_AVR_ATMEGA808",
+    "extra_flags": "-DARDUINO_AVR_ATmega808",
     "f_cpu": "16000000L",
     "mcu": "atmega808",
     "variant": "32pin-standard"

--- a/boards/ATmega809.json
+++ b/boards/ATmega809.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "MegaCoreX",
-    "extra_flags": "-DARDUINO_AVR_ATMEGA809",
+    "extra_flags": "-DARDUINO_AVR_ATmega809",
     "f_cpu": "16000000L",
     "mcu": "atmega809",
     "variant": "48pin-standard"

--- a/boards/avr_iot_wg.json
+++ b/boards/avr_iot_wg.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "MegaCoreX",
-    "extra_flags": "-DARDUINO_AVR_ATMEGA4808",
+    "extra_flags": "-DARDUINO_AVR_ATmega4808",
     "f_cpu": "16000000L",
     "mcu": "atmega4808",
     "variant": "32pin-standard"

--- a/boards/curiosity_nano_4809.json
+++ b/boards/curiosity_nano_4809.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "MegaCoreX",
-    "extra_flags": "-DARDUINO_AVR_ATMEGA4809",
+    "extra_flags": "-DARDUINO_AVR_ATmega4809",
     "f_cpu": "16000000L",
     "mcu": "atmega4809",
     "variant": "48pin-standard"

--- a/boards/xplained_pro_4809.json
+++ b/boards/xplained_pro_4809.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "MegaCoreX",
-    "extra_flags": "-DARDUINO_AVR_ATMEGA4809",
+    "extra_flags": "-DARDUINO_AVR_ATmega4809",
     "f_cpu": "16000000L",
     "mcu": "atmega4809",
     "variant": "48pin-standard"


### PR DESCRIPTION
These macros are used by some library providers such as Adafruit. #26 related.