### PR TITLE
DxCore - add Curiosity Nano boards

### DIFF
--- a/boards/AVR128DA28.json
+++ b/boards/AVR128DA28.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR128DA28 -DARDUINO_avrda -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR128DA28 -DARDUINO_avrda",
     "f_cpu": "24000000L",
     "mcu": "avr128da28",
     "variant": "28pin-standard"

--- a/boards/AVR128DA32.json
+++ b/boards/AVR128DA32.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR128DA32 -DARDUINO_avrda -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR128DA32 -DARDUINO_avrda",
     "f_cpu": "24000000L",
     "mcu": "avr128da32",
     "variant": "32pin-standard"

--- a/boards/AVR128DA48.json
+++ b/boards/AVR128DA48.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR128DA48 -DARDUINO_avrda -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR128DA48 -DARDUINO_avrda",
     "f_cpu": "24000000L",
     "mcu": "avr128da48",
     "variant": "48pin-standard"

--- a/boards/AVR128DA64.json
+++ b/boards/AVR128DA64.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR128DA64 -DARDUINO_avrda -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR128DA64 -DARDUINO_avrda",
     "f_cpu": "24000000L",
     "mcu": "avr128da64",
     "variant": "64pin-standard"

--- a/boards/AVR128DB28.json
+++ b/boards/AVR128DB28.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR128DB28 -DARDUINO_avrdb -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR128DB28 -DARDUINO_avrdb",
     "f_cpu": "24000000L",
     "mcu": "avr128db28",
     "variant": "28pin-standard"

--- a/boards/AVR128DB32.json
+++ b/boards/AVR128DB32.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR128DB32 -DARDUINO_avrdb -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR128DB32 -DARDUINO_avrdb",
     "f_cpu": "24000000L",
     "mcu": "avr128db32",
     "variant": "32pin-standard"

--- a/boards/AVR128DB48.json
+++ b/boards/AVR128DB48.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR128DB48 -DARDUINO_avrdb -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR128DB48 -DARDUINO_avrdb",
     "f_cpu": "24000000L",
     "mcu": "avr128db48",
     "variant": "48pin-standard"

--- a/boards/AVR128DB64.json
+++ b/boards/AVR128DB64.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR128DB64 -DARDUINO_avrdb -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR128DB64 -DARDUINO_avrdb",
     "f_cpu": "24000000L",
     "mcu": "avr128db64",
     "variant": "64pin-standard"

--- a/boards/AVR32DA28.json
+++ b/boards/AVR32DA28.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR32DA28 -DARDUINO_avrda -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR32DA28 -DARDUINO_avrda",
     "f_cpu": "24000000L",
     "mcu": "avr32da28",
     "variant": "28pin-standard"

--- a/boards/AVR32DA32.json
+++ b/boards/AVR32DA32.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR32DA32 -DARDUINO_avrda -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR32DA32 -DARDUINO_avrda",
     "f_cpu": "24000000L",
     "mcu": "avr32da32",
     "variant": "32pin-standard"

--- a/boards/AVR32DA48.json
+++ b/boards/AVR32DA48.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR32DA48 -DARDUINO_avrda -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR32DA48 -DARDUINO_avrda",
     "f_cpu": "24000000L",
     "mcu": "avr32da48",
     "variant": "48pin-standard"

--- a/boards/AVR32DB28.json
+++ b/boards/AVR32DB28.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR32DB28 -DARDUINO_avrdb -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR32DB28 -DARDUINO_avrdb",
     "f_cpu": "24000000L",
     "mcu": "avr32db28",
     "variant": "28pin-standard"

--- a/boards/AVR32DB32.json
+++ b/boards/AVR32DB32.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR32DB32 -DARDUINO_avrdb -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR32DB32 -DARDUINO_avrdb",
     "f_cpu": "24000000L",
     "mcu": "avr32db32",
     "variant": "32pin-standard"

--- a/boards/AVR32DB48.json
+++ b/boards/AVR32DB48.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR32DB48 -DARDUINO_avrdb -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR32DB48 -DARDUINO_avrdb",
     "f_cpu": "24000000L",
     "mcu": "avr32db48",
     "variant": "48pin-standard"

--- a/boards/AVR64DA28.json
+++ b/boards/AVR64DA28.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR64DA28 -DARDUINO_avrda -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR64DA28 -DARDUINO_avrda",
     "f_cpu": "24000000L",
     "mcu": "avr64da28",
     "variant": "28pin-standard"

--- a/boards/AVR64DA32.json
+++ b/boards/AVR64DA32.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR64DA32 -DARDUINO_avrda -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR64DA32 -DARDUINO_avrda",
     "f_cpu": "24000000L",
     "mcu": "avr64da32",
     "variant": "32pin-standard"

--- a/boards/AVR64DA48.json
+++ b/boards/AVR64DA48.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR64DA48 -DARDUINO_avrda -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR64DA48 -DARDUINO_avrda",
     "f_cpu": "24000000L",
     "mcu": "avr64da48",
     "variant": "48pin-standard"

--- a/boards/AVR64DA64.json
+++ b/boards/AVR64DA64.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR64DA64 -DARDUINO_avrda -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR64DA64 -DARDUINO_avrda",
     "f_cpu": "24000000L",
     "mcu": "avr64da64",
     "variant": "64pin-standard"

--- a/boards/AVR64DB28.json
+++ b/boards/AVR64DB28.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR64DB28 -DARDUINO_avrdb -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR64DB28 -DARDUINO_avrdb",
     "f_cpu": "24000000L",
     "mcu": "avr64db28",
     "variant": "28pin-standard"

--- a/boards/AVR64DB32.json
+++ b/boards/AVR64DB32.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR64DB32 -DARDUINO_avrdb -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR64DB32 -DARDUINO_avrdb",
     "f_cpu": "24000000L",
     "mcu": "avr64db32",
     "variant": "32pin-standard"

--- a/boards/AVR64DB48.json
+++ b/boards/AVR64DB48.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR64DB48 -DARDUINO_avrdb -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR64DB48 -DARDUINO_avrdb",
     "f_cpu": "24000000L",
     "mcu": "avr64db48",
     "variant": "48pin-standard"

--- a/boards/AVR64DB64.json
+++ b/boards/AVR64DB64.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR64DB64 -DARDUINO_avrdb -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR64DB64 -DARDUINO_avrdb",
     "f_cpu": "24000000L",
     "mcu": "avr64db64",
     "variant": "64pin-standard"

--- a/boards/AVR64DD14.json
+++ b/boards/AVR64DD14.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR64DD14 -DARDUINO_avrdd -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR64DD14 -DARDUINO_avrdd",
     "f_cpu": "24000000L",
     "mcu": "avr64dd14",
     "variant": "14pin-standard"

--- a/boards/AVR64DD20.json
+++ b/boards/AVR64DD20.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR64DD20 -DARDUINO_avrdd -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR64DD20 -DARDUINO_avrdd",
     "f_cpu": "24000000L",
     "mcu": "avr64dd20",
     "variant": "20pin-standard"

--- a/boards/AVR64DD28.json
+++ b/boards/AVR64DD28.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR64DD28 -DARDUINO_avrdd -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR64DD28 -DARDUINO_avrdd",
     "f_cpu": "24000000L",
     "mcu": "avr64dd28",
     "variant": "28pin-standard"

--- a/boards/AVR64DD32.json
+++ b/boards/AVR64DD32.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "dxcore",
-    "extra_flags": "-DARDUINO_AVR_AVR64DD32 -DARDUINO_avrdd -DMILLIS_USE_TIMERB0",
+    "extra_flags": "-DARDUINO_AVR_AVR64DD32 -DARDUINO_avrdd",
     "f_cpu": "24000000L",
     "mcu": "avr64dd32",
     "variant": "32pin-standard"

--- a/boards/curiosity_nano_da.json
+++ b/boards/curiosity_nano_da.json
@@ -16,7 +16,7 @@
   "upload": {
     "maximum_ram_size": 16384,
     "maximum_size": 131072,
-    "protocol": "curiosity_updi"
+    "protocol": "pkobn_updi"
   },
   "url": "https://www.microchip.com/developmenttools/ProductDetails/DM164151",
   "vendor": "Microchip"

--- a/boards/curiosity_nano_da.json
+++ b/boards/curiosity_nano_da.json
@@ -1,0 +1,23 @@
+{
+  "build": {
+    "core": "dxcore",
+    "extra_flags": "-DARDUINO_AVR_AVR128DA48 -DARDUINO_avrda -DLED_BUILTIN=PIN_PC6",
+    "f_cpu": "24000000L",
+    "mcu": "avr128da48",
+    "variant": "48pin-standard"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Curiosity Nano AVR128DA48",
+  "upload": {
+    "maximum_ram_size": 16384,
+    "maximum_size": 131072,
+    "protocol": "curiosity_updi"
+  },
+  "url": "https://www.microchip.com/developmenttools/ProductDetails/DM164151",
+  "vendor": "Microchip"
+}

--- a/boards/curiosity_nano_db.json
+++ b/boards/curiosity_nano_db.json
@@ -16,7 +16,7 @@
   "upload": {
     "maximum_ram_size": 16384,
     "maximum_size": 131072,
-    "protocol": "curiosity_updi"
+    "protocol": "pkobn_updi"
   },
   "url": "https://www.microchip.com/developmenttools/ProductDetails/EV35L43A",
   "vendor": "Microchip"

--- a/boards/curiosity_nano_db.json
+++ b/boards/curiosity_nano_db.json
@@ -1,0 +1,23 @@
+{
+  "build": {
+    "core": "dxcore",
+    "extra_flags": "-DARDUINO_AVR_AVR128DB48 -DARDUINO_avrdb -DLED_BUILTIN=PIN_PB3",
+    "f_cpu": "24000000L",
+    "mcu": "avr128db48",
+    "variant": "48pin-standard"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "Curiosity Nano AVR128DB48",
+  "upload": {
+    "maximum_ram_size": 16384,
+    "maximum_size": 131072,
+    "protocol": "curiosity_updi"
+  },
+  "url": "https://www.microchip.com/developmenttools/ProductDetails/EV35L43A",
+  "vendor": "Microchip"
+}

--- a/examples/arduino-blink/platformio.ini
+++ b/examples/arduino-blink/platformio.ini
@@ -81,7 +81,7 @@ board = AVR128DA64
 [env:AVR128DA48]
 platform = atmelmegaavr
 framework = arduino
-board = AVR128DA48
+board = curiosity_nano_da
 
 [env:AVR128DA32]
 platform = atmelmegaavr
@@ -107,3 +107,8 @@ board = AVR32DB32
 platform = atmelmegaavr
 framework = arduino
 board = AVR32DB48
+
+[env:AVR128DB48]
+platform = atmelmegaavr
+framework = arduino
+board = curiosity_nano_db

--- a/examples/arduino-internal-libs/platformio.ini
+++ b/examples/arduino-internal-libs/platformio.ini
@@ -25,7 +25,7 @@ board = AVR128DA64
 [env:AVR128DA48]
 platform = atmelmegaavr
 framework = arduino
-board = AVR128DA48
+board = curiosity_nano_da
 
 [env:AVR128DA32]
 platform = atmelmegaavr
@@ -51,3 +51,8 @@ board = AVR32DB32
 platform = atmelmegaavr
 framework = arduino
 board = AVR32DB48
+
+[env:AVR128DB48]
+platform = atmelmegaavr
+framework = arduino
+board = curiosity_nano_db

--- a/examples/native-blink/platformio.ini
+++ b/examples/native-blink/platformio.ini
@@ -23,9 +23,14 @@ board = AVR128DA64
 [env:AVR128DA48]
 platform = atmelmegaavr
 framework = arduino
-board = AVR128DA48
+board = curiosity_nano_da
 
 [env:AVR32DB48]
 platform = atmelmegaavr
 framework = arduino
 board = AVR32DB48
+
+[env:AVR128DB48]
+platform = atmelmegaavr
+framework = arduino
+board = curiosity_nano_db


### PR DESCRIPTION
I added the Curiosity Nano DA & DB board definitions.
- https://www.microchip.com/developmenttools/ProductDetails/DM164151
- https://www.microchip.com/developmenttools/ProductDetails/EV35L43A

I confirmed that the build and upload work on my Curiosity Nano AVR128DA48, both on windows (as-is) and linux (avrdude fixed #31).

Also, since MILLIS_USE_TIMER is defined in arduino.py, I removed the compiler flag from every .json board definitions, because they were conflicting.