### PR TITLE
Add support for the entire tinyAVR-2 family

### DIFF
--- a/boards/ATtiny1624.json
+++ b/boards/ATtiny1624.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megatinycore",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny1624",
+    "variant": "txy4"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny1624",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 16384,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY1624",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny1626.json
+++ b/boards/ATtiny1626.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megatinycore",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny1626",
+    "variant": "txy6"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny1626",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 16384,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY1626",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny1627.json
+++ b/boards/ATtiny1627.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megatinycore",
+    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny1627",
+    "variant": "txy7"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny1627",
+  "upload": {
+    "maximum_ram_size": 2048,
+    "maximum_size": 16384,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY1627",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny3224.json
+++ b/boards/ATtiny3224.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megatinycore",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny3224",
+    "variant": "txy4"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny3224",
+  "upload": {
+    "maximum_ram_size": 3072,
+    "maximum_size": 32768,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY3224",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny3226.json
+++ b/boards/ATtiny3226.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megatinycore",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny3226",
+    "variant": "txy6"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny3226",
+  "upload": {
+    "maximum_ram_size": 3072,
+    "maximum_size": 32768,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY3226",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny3227.json
+++ b/boards/ATtiny3227.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megatinycore",
+    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny3227",
+    "variant": "txy7"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny3227",
+  "upload": {
+    "maximum_ram_size": 3072,
+    "maximum_size": 32768,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY3227",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny424.json
+++ b/boards/ATtiny424.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megatinycore",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny424",
+    "variant": "txy4"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny424",
+  "upload": {
+    "maximum_ram_size": 512,
+    "maximum_size": 4096,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY424",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny426.json
+++ b/boards/ATtiny426.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megatinycore",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny426",
+    "variant": "txy6"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny426",
+  "upload": {
+    "maximum_ram_size": 512,
+    "maximum_size": 4096,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY426",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny427.json
+++ b/boards/ATtiny427.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megatinycore",
+    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny427",
+    "variant": "txy7"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny427",
+  "upload": {
+    "maximum_ram_size": 512,
+    "maximum_size": 4096,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY427",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny824.json
+++ b/boards/ATtiny824.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megatinycore",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny824",
+    "variant": "txy4"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny824",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 8192,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY824",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny826.json
+++ b/boards/ATtiny826.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megatinycore",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny826",
+    "variant": "txy6"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny826",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 8192,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY826",
+  "vendor": "Microchip"
+}

--- a/boards/ATtiny827.json
+++ b/boards/ATtiny827.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megatinycore",
+    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "f_cpu": "16000000L",
+    "mcu": "attiny827",
+    "variant": "txy7"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny827",
+  "upload": {
+    "maximum_ram_size": 1024,
+    "maximum_size": 8192,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY827",
+  "vendor": "Microchip"
+}


### PR DESCRIPTION
Support for the entire tinyAVR-2 series is currently missing. This PR solved this.

Closes #25 
Closes https://github.com/platformio/platform-atmelavr/issues/268
Closes https://github.com/platformio/platform-atmelavr/issues/263
