### PR TITLE
Add support for 1200bps touch

### DIFF
--- a/boards/nano_every.json
+++ b/boards/nano_every.json
@@ -27,6 +27,7 @@
     "maximum_ram_size": 6144,
     "maximum_size": 48640,
     "protocol": "jtag2updi",
+    "use_1200bps_touch": true,
     "speed": 115200
   },
   "url": "https://www.arduino.cc/en/Guide/NANOEvery",

--- a/builder/fuses.py
+++ b/builder/fuses.py
@@ -236,7 +236,7 @@ if int(ARGUMENTS.get("PIOVERBOSE", 0)):
     env.Append(FUSESUPLOADERFLAGS=["-v"])
 
 # Add upload serial port to Avrdude flags list if a jtag2updi programmer
-if env.subst("$UPLOAD_PROTOCOL") == "jtag2updi":
+if env.subst("$UPLOAD_PROTOCOL") in ("jtag2updi", "serialupdi"):
     env.AutodetectUploadPort()
     env.Append(FUSESUPLOADERFLAGS=["-P", '"$UPLOAD_PORT"'])
 else:

--- a/builder/fuses.py
+++ b/builder/fuses.py
@@ -2,7 +2,6 @@ import sys
 import os
 
 from SCons.Script import ARGUMENTS, COMMAND_LINE_TARGETS, Import, Return
-from platformio.util import get_serial_ports
 
 Import("env")
 
@@ -255,7 +254,6 @@ else:
     )
 
 print_fuses_info(fuse_values, fuse_names, lock_fuse)
-
 
 fuses_action = env.VerboseAction("$SETFUSESCMD", "Setting fuses...")
 

--- a/builder/fuses.py
+++ b/builder/fuses.py
@@ -258,7 +258,7 @@ print_fuses_info(fuse_values, fuse_names, lock_fuse)
 
 # Handle jtag2updi 1200bps uart touch (present on Arduino Nano Every)
 upload_options = env.BoardConfig().get("upload", {})
-if upload_options.get("use_1200bps_touch", False) == "true":
+if upload_options.get("use_1200bps_touch", False) in (True, "true"):
     before_ports = get_serial_ports()
     env.AutodetectUploadPort()
     env.TouchSerialPort("$UPLOAD_PORT", 1200)

--- a/builder/fuses.py
+++ b/builder/fuses.py
@@ -256,15 +256,6 @@ else:
 
 print_fuses_info(fuse_values, fuse_names, lock_fuse)
 
-# Handle jtag2updi 1200bps uart touch (present on Arduino Nano Every)
-upload_options = env.BoardConfig().get("upload", {})
-if upload_options.get("use_1200bps_touch", False) in (True, "true"):
-    before_ports = get_serial_ports()
-    env.AutodetectUploadPort()
-    env.TouchSerialPort("$UPLOAD_PORT", 1200)
-    if upload_options.get("wait_for_upload_port", True):
-        env.Replace(UPLOAD_PORT=env.WaitForNewSerialPort(before_ports))
-
 
 fuses_action = env.VerboseAction("$SETFUSESCMD", "Setting fuses...")
 

--- a/builder/main.py
+++ b/builder/main.py
@@ -169,10 +169,13 @@ target_size = env.AddPlatformTarget(
 # Target: Setup fuses
 #
 
-fuses_action = None
+fuses_actions = None
 if "fuses" in COMMAND_LINE_TARGETS:
-    fuses_action = env.SConscript("fuses.py", exports="env")
-env.AddPlatformTarget("fuses", None, fuses_action, "Set Fuses")
+    fuses_actions = [
+        env.VerboseAction(BeforeUpload, "Looking for port..."),
+        env.SConscript("fuses.py", exports="env")
+    ]
+env.AddPlatformTarget("fuses", None, fuses_actions, "Set Fuses")
 
 #
 # Target: Upload bootloader
@@ -198,11 +201,8 @@ else:
     ]
 
     upload_options = env.BoardConfig().get("upload", {})
-    # jtag2updi seems to be the only protocol that requires serial port
-    if upload_protocol == "jtag2updi":
+    if upload_protocol in ("jtag2updi", "serialupdi"):
         upload_options["require_upload_port"] = True
-        upload_options["use_1200bps_touch"] = True
-        upload_options["wait_for_upload_port"] = False
     elif upload_protocol == "arduino":
         upload_options["require_upload_port"] = True
         upload_options["use_1200bps_touch"] = False


### PR DESCRIPTION
Add support for 1200bps touch improve upload port handling. Now -P USB is added if the programmer is not a jtag2updi, and -P $UPLOAD_PORT if the programmer is a jtag2updi. This can be done because the jtag2updi programmer is currently the only UPDI programmer that communicates over UART.

Would be great if you can test and verify that it works for you @maxgerhardt 

Closes #34