### PR TITLE
Fix millis for all tinyAVR-2 targets

### DIFF
--- a/boards/ATtiny1624.json
+++ b/boards/ATtiny1624.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "megatinycore",
-    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERB1 -DUARTBAUD5V",
     "f_cpu": "16000000L",
     "mcu": "attiny1624",
     "variant": "txy4"

--- a/boards/ATtiny1626.json
+++ b/boards/ATtiny1626.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "megatinycore",
-    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERB1 -DUARTBAUD5V",
     "f_cpu": "16000000L",
     "mcu": "attiny1626",
     "variant": "txy6"

--- a/boards/ATtiny1627.json
+++ b/boards/ATtiny1627.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "megatinycore",
-    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERB1 -DUARTBAUD5V",
     "f_cpu": "16000000L",
     "mcu": "attiny1627",
     "variant": "txy7"

--- a/boards/ATtiny3224.json
+++ b/boards/ATtiny3224.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "megatinycore",
-    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERB1 -DUARTBAUD5V",
     "f_cpu": "16000000L",
     "mcu": "attiny3224",
     "variant": "txy4"

--- a/boards/ATtiny3226.json
+++ b/boards/ATtiny3226.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "megatinycore",
-    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERB1 -DUARTBAUD5V",
     "f_cpu": "16000000L",
     "mcu": "attiny3226",
     "variant": "txy6"

--- a/boards/ATtiny3227.json
+++ b/boards/ATtiny3227.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "megatinycore",
-    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERB1 -DUARTBAUD5V",
     "f_cpu": "16000000L",
     "mcu": "attiny3227",
     "variant": "txy7"

--- a/boards/ATtiny424.json
+++ b/boards/ATtiny424.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "megatinycore",
-    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERB1 -DUARTBAUD5V",
     "f_cpu": "16000000L",
     "mcu": "attiny424",
     "variant": "txy4"

--- a/boards/ATtiny426.json
+++ b/boards/ATtiny426.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "megatinycore",
-    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERB1 -DUARTBAUD5V",
     "f_cpu": "16000000L",
     "mcu": "attiny426",
     "variant": "txy6"

--- a/boards/ATtiny427.json
+++ b/boards/ATtiny427.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "megatinycore",
-    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERB1 -DUARTBAUD5V",
     "f_cpu": "16000000L",
     "mcu": "attiny427",
     "variant": "txy7"

--- a/boards/ATtiny824.json
+++ b/boards/ATtiny824.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "megatinycore",
-    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "extra_flags": "-DARDUINO_attinyxy4 -DMILLIS_USE_TIMERB1 -DUARTBAUD5V",
     "f_cpu": "16000000L",
     "mcu": "attiny824",
     "variant": "txy4"

--- a/boards/ATtiny826.json
+++ b/boards/ATtiny826.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "megatinycore",
-    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERB1 -DUARTBAUD5V",
     "f_cpu": "16000000L",
     "mcu": "attiny826",
     "variant": "txy6"

--- a/boards/ATtiny827.json
+++ b/boards/ATtiny827.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "core": "megatinycore",
-    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERD0 -DUARTBAUD5V",
+    "extra_flags": "-DARDUINO_attinyxy7 -DMILLIS_USE_TIMERB1 -DUARTBAUD5V",
     "f_cpu": "16000000L",
     "mcu": "attiny827",
     "variant": "txy7"


### PR DESCRIPTION
Timer TCD0 doesn't exist on these parts. Use the default megaTinyCore timer instead, TCB1.