### PR TITLE
Updated upload protocol for AVR-IoT-WG

### DIFF
--- a/boards/avr_iot_wg.json
+++ b/boards/avr_iot_wg.json
@@ -16,7 +16,7 @@
   "upload": {
     "maximum_ram_size": 6144,
     "maximum_size": 49152,
-    "protocol": "curiosity_updi"
+    "protocol": "pkobn_updi"
   },
   "url": "https://www.microchip.com/developmenttools/ProductDetails/AC164160",
   "vendor": "Microchip"


### PR DESCRIPTION
The existing `curiosity_updi` is not compatible with AVR-IoT-Wx board. Instead, `pkobn_updi` has to be used as per the Microchip documentation.

Tested working on AVR-IoT-WA board (same as AVR-IoT-WG).