### PR TITLE
Fix incorrect programmer names in board manifest files

### DIFF
--- a/boards/avr_iot_wg.json
+++ b/boards/avr_iot_wg.json
@@ -16,7 +16,7 @@
   "upload": {
     "maximum_ram_size": 6144,
     "maximum_size": 49152,
-    "protocol": "curiosity_updi"
+    "protocol": "pkobn_updi"
   },
   "url": "https://www.microchip.com/developmenttools/ProductDetails/AC164160",
   "vendor": "Microchip"

--- a/boards/curiosity_nano_4809.json
+++ b/boards/curiosity_nano_4809.json
@@ -16,7 +16,7 @@
   "upload": {
     "maximum_ram_size": 6144,
     "maximum_size": 49152,
-    "protocol": "curiosity_updi"
+    "protocol": "pkobn_updi"
   },
   "url": "https://www.microchip.com/developmenttools/ProductDetails/DM320115",
   "vendor": "Microchip"


### PR DESCRIPTION
This PR supersedes #43 and resolves incorrect programmer names for two boards.

@valeros this PR can be merged as it is, and hopefully before the next platform release.