### PR TITLE
Add definition for Microchip ATtiny416 Xplained Nano.

### DIFF
--- a/boards/xplained_nano_416.json
+++ b/boards/xplained_nano_416.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "megatinycore",
+    "extra_flags": "-DARDUINO_attinyxy6 -DMILLIS_USE_TIMERD0 -DLED_BUILTIN=PIN_PB5 -DPIN_BUTTON_BUILTIN=PIN_PB4",
+    "f_cpu": "20000000L",
+    "mcu": "attiny416",
+    "variant": "txy6"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "ATtiny416 Xplained Nano",
+  "upload": {
+    "maximum_ram_size": 256,
+    "maximum_size": 4096,
+    "protocol": "xplainedmini_updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/ATTINY416",
+  "vendor": "Microchip"
+}


### PR DESCRIPTION
Add definition for Microchip ATtiny416 Xplained Nano.

https://www.microchip.com/en-us/development-tool/ATTINY416-XNANO

Exmaple platformio.ini
```
[env:ATtiny416]
platform = atmelmegaavr
board = xplained_nano_416
framework = arduino
```