### PR TITLE
Fix serial port issue in Bootloader.py script

### DIFF
--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -124,8 +124,10 @@ env.Append(
     UPLOADBOOTCMD="$BOOTUPLOADER $BOOTUPLOADERFLAGS $UPLOAD_FLAGS $BOOTFLAGS",
 )
 
-# Add upload serial port to Avrdude flags list if a jtag2updi or serialupdi programmer
-if env.subst("$UPLOAD_PROTOCOL") in ("jtag2updi", "serialupdi"):
+if env.subst("$UPLOAD_PROTOCOL") in (
+    "jtag2updi",
+    "serialupdi",
+) or env.BoardConfig().get("upload", {}).get("require_upload_port", False):
     env.AutodetectUploadPort()
     env.Append(BOOTUPLOADERFLAGS=["-P", '"$UPLOAD_PORT"'])
 else:

--- a/builder/bootloader.py
+++ b/builder/bootloader.py
@@ -124,12 +124,13 @@ env.Append(
     UPLOADBOOTCMD="$BOOTUPLOADER $BOOTUPLOADERFLAGS $UPLOAD_FLAGS $BOOTFLAGS",
 )
 
-if not env.BoardConfig().get("upload", {}).get("require_upload_port", False):
+# Add upload serial port to Avrdude flags list if a jtag2updi or serialupdi programmer
+if env.subst("$UPLOAD_PROTOCOL") in ("jtag2updi", "serialupdi"):
+    env.AutodetectUploadPort()
+    env.Append(BOOTUPLOADERFLAGS=["-P", '"$UPLOAD_PORT"'])
+else:
     # upload methods via USB
     env.Append(BOOTUPLOADERFLAGS=["-P", "usb"])
-else:
-    env.AutodetectUploadPort()
-    env.Append(FUSESUPLOADERFLAGS=["-P", '"$UPLOAD_PORT"'])
 
 if env.subst("$UPLOAD_PROTOCOL") != "custom":
     env.Append(BOOTUPLOADERFLAGS=["-c", "$UPLOAD_PROTOCOL"])


### PR DESCRIPTION
First reported here: https://github.com/MCUdude/MegaCoreX/issues/193

When burning a bootloader using PlatformIO, the bootloader script are mistakenly adding `-P usb` as the Avrdude upload port, even though the serialupdi programmer is a serial device. This is not a problem in the fuses.py script, so I simply copied the logic from there.

@valeros it would be great if you could give this a review!

<details>

<summary>platformio.ini file</summary>

```ini
[env]
platform = atmelmegaavr
framework = arduino

board = ATmega4809
; Clock frequency in [Hz]
board_build.f_cpu = 4000000L
; Oscillator type (internal or external)
board_hardware.oscillator = internal
; Arduino pinout variant
board_build.variant = 40pin-standard

; Monitor port is auto detected. Override here
;monitor_port =
monitor_speed = 9600
monitor_dtr = 0


; Run the following command to upload with this environment
; pio run -t upload
[env:Upload_UPDI]
; Upload protocol for UPDI upload
upload_protocol = serialupdi
upload_port = /dev/cu.usbserial-1410
; COM1 or COM3
upload_speed = 115200
upload_flags =
  -xrtsdtr=high


; run the following command to set fuses
; pio run -e fuses_bootloader -t fuses
; run the following command to set fuses + burn bootloader
; pio run -e fuses_bootloader -t bootloader -F -v
[env:fuses_bootloader]
; Inherit upload settings from the Upload_UPDI environment
extends = env:Upload_UPDI
; Hardware settings
board_hardware.bod = 2.6v
board_hardware.eesave = yes
board_hardware.uart = uart0
board_hardware.rstpin = reset
```

</details>

```
pio run -t bootloader -e fuses_bootloader -v
Processing fuses_bootloader (extends: env:Upload_UPDI; board_hardware.bod: 2.6v; board_hardware.eesave: yes; board_hardware.uart: uart0; board_hardware.rstpin: reset; upload_protocol: serialupdi; upload_port: /dev/cu.usbserial-1410; upload_speed: 115200; upload_flags: -xrtsdtr=high; platform: atmelmegaavr; framework: arduino; board: ATmega4809; board_build.f_cpu: 4000000L; board_hardware.oscillator: internal; board_build.variant: 40pin-standard; monitor_speed: 9600; monitor_dtr: 0)
--------------------------------------------------------------------------------------------------------------------------------------------------
CONFIGURATION: https://docs.platformio.org/page/boards/atmelmegaavr/ATmega4809.html
PLATFORM: Atmel megaAVR (1.9.0) > ATmega4809
HARDWARE: ATMEGA4809 4MHz, 6KB RAM, 48KB Flash
PACKAGES: 
 - framework-arduino-megaavr-megacorex @ 1.1.2 
 - tool-avrdude @ 1.70100.0 (7.1.0) 
 - toolchain-atmelavr @ 1.70300.191015 (7.3.0)
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 11 compatible libraries
Scanning dependencies...
No dependencies
Building in release mode

TARGET CONFIGURATION:
-------------------------
Target = atmega4809
Clock speed = 4000000L
Oscillator = internal
BOD level = 2.6v
Save EEPROM = yes
Reset pin mode = reset
-------------------------
Using manually specified: /dev/cu.usbserial-1410

Selected fuses:
-------------------------
[fuse0 / wdtcfg   = 0x00]
[fuse1 / bodcfg   = 0x54]
[fuse2 / osccfg   = 0x01]
[fuse4 / tcd0cfg  = 0x00]
[fuse5 / syscfg0  = 0xC9]
[fuse6 / syscfg1  = 0x06]
[fuse7 / append   = 0x00]
[fuse8 / bootend  = 0x02]
[lock  / lockbit  = 0xC5]
-------------------------

avrdude -p atmega4809 -C /Users/hans/.platformio/packages/tool-avrdude/avrdude.conf -v -P "/dev/cu.usbserial-1410" -c serialupdi -xrtsdtr=high -Ufuse0:w:0x00:m -Ufuse1:w:0x54:m -Ufuse2:w:0x01:m -Ufuse4:w:0x00:m -Ufuse5:w:0xC9:m -Ufuse6:w:0x06:m -Ufuse7:w:0x00:m -Ufuse8:w:0x02:m -Ulock:w:0xC5:m

avrdude: Version 7.1-arduino.1
         Copyright the AVRDUDE authors;
         see https://github.com/avrdudes/avrdude/blob/main/AUTHORS

         System wide configuration file is /Users/hans/.platformio/packages/tool-avrdude/avrdude.conf
         User configuration file is /Users/hans/.avrduderc
         User configuration file does not exist or is not a regular file, skipping

         Using Port                    : /dev/cu.usbserial-1410
         Using Programmer              : serialupdi
         AVR Part                      : ATmega4809
         RESET disposition             : dedicated
         RETRY pulse                   : SCK
         Serial program mode           : yes
         Parallel program mode         : yes
         Memory Detail                 :

                                           Block Poll               Page                       Polled
           Memory Type Alias    Mode Delay Size  Indx Paged  Size   Size #Pages MinW  MaxW   ReadBack
           ----------- -------- ---- ----- ----- ---- ------ ------ ---- ------ ----- ----- ---------
           fuse0       wdtcfg      0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse1       bodcfg      0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse2       osccfg      0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse4       tcd0cfg     0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse5       syscfg0     0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse6       syscfg1     0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse7       append      0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuse8       bootend     0     0     0    0 no          1    1      0     0     0 0x00 0x00
           fuses                   0     0     0    0 no          9   10      0     0     0 0x00 0x00
           lock                    0     0     0    0 no          1    1      0     0     0 0x00 0x00
           tempsense               0     0     0    0 no          2    1      0     0     0 0x00 0x00
           signature               0     0     0    0 no          3    1      0     0     0 0x00 0x00
           prodsig                 0     0     0    0 no         61   61      0     0     0 0x00 0x00
           sernum                  0     0     0    0 no         10    1      0     0     0 0x00 0x00
           osccal16                0     0     0    0 no          2    1      0     0     0 0x00 0x00
           osccal20                0     0     0    0 no          2    1      0     0     0 0x00 0x00
           osc16err                0     0     0    0 no          2    1      0     0     0 0x00 0x00
           osc20err                0     0     0    0 no          2    1      0     0     0 0x00 0x00
           data                    0     0     0    0 no          0    1      0     0     0 0x00 0x00
           userrow     usersig     0     0     0    0 no         64   64      0     0     0 0x00 0x00
           eeprom                  0     0     0    0 no        256   64      0     0     0 0x00 0x00
           flash                   0     0     0    0 no      49152  128      0     0     0 0x00 0x00

         Programmer Type : serialupdi
         Description     : SerialUPDI

avrdude serialupdi_initialize() warning: forcing serial DTR/RTS handshake lines HIGH
avrdude: NVM type 0: 16-bit, page oriented write
avrdude: entering NVM programming mode
avrdude: AVR device initialized and ready to accept instructions
avrdude: device signature = 0x1e9651 (probably m4809)
avrdude: reading input file 0x00 for fuse0/wdtcfg
         with 1 byte in 1 section within [0, 0]
avrdude: writing 1 byte fuse0/wdtcfg ...
avrdude: 1 byte of fuse0/wdtcfg written
avrdude: verifying fuse0/wdtcfg memory against 0x00
avrdude: 1 byte of fuse0/wdtcfg verified
avrdude: reading input file 0x54 for fuse1/bodcfg
         with 1 byte in 1 section within [0, 0]
avrdude: writing 1 byte fuse1/bodcfg ...
avrdude: 1 byte of fuse1/bodcfg written
avrdude: verifying fuse1/bodcfg memory against 0x54
avrdude: 1 byte of fuse1/bodcfg verified
avrdude: reading input file 0x01 for fuse2/osccfg
         with 1 byte in 1 section within [0, 0]
avrdude: writing 1 byte fuse2/osccfg ...
avrdude: 1 byte of fuse2/osccfg written
avrdude: verifying fuse2/osccfg memory against 0x01
avrdude: 1 byte of fuse2/osccfg verified
avrdude: reading input file 0x00 for fuse4/tcd0cfg
         with 1 byte in 1 section within [0, 0]
avrdude: writing 1 byte fuse4/tcd0cfg ...
avrdude: 1 byte of fuse4/tcd0cfg written
avrdude: verifying fuse4/tcd0cfg memory against 0x00
avrdude: 1 byte of fuse4/tcd0cfg verified
avrdude: reading input file 0xC9 for fuse5/syscfg0
         with 1 byte in 1 section within [0, 0]
avrdude: writing 1 byte fuse5/syscfg0 ...
avrdude: 1 byte of fuse5/syscfg0 written
avrdude: verifying fuse5/syscfg0 memory against 0xC9
avrdude: 1 byte of fuse5/syscfg0 verified
avrdude: reading input file 0x06 for fuse6/syscfg1
         with 1 byte in 1 section within [0, 0]
avrdude: writing 1 byte fuse6/syscfg1 ...
avrdude: 1 byte of fuse6/syscfg1 written
avrdude: verifying fuse6/syscfg1 memory against 0x06
avrdude: 1 byte of fuse6/syscfg1 verified
avrdude: reading input file 0x00 for fuse7/append
         with 1 byte in 1 section within [0, 0]
avrdude: writing 1 byte fuse7/append ...
avrdude: 1 byte of fuse7/append written
avrdude: verifying fuse7/append memory against 0x00
avrdude: 1 byte of fuse7/append verified
avrdude: reading input file 0x02 for fuse8/bootend
         with 1 byte in 1 section within [0, 0]
avrdude: writing 1 byte fuse8/bootend ...
avrdude: 1 byte of fuse8/bootend written
avrdude: verifying fuse8/bootend memory against 0x02
avrdude: 1 byte of fuse8/bootend verified
avrdude: reading input file 0xC5 for lock
         with 1 byte in 1 section within [0, 0]
avrdude: writing 1 byte lock ...
avrdude: 1 byte of lock written
avrdude: verifying lock memory against 0xC5
avrdude: 1 byte of lock verified
avrdude: leaving NVM programming mode
avrdude serialupdi_close() warning: releasing DTR/RTS handshake lines

avrdude done.  Thank you.

avrdude -p atmega4809 -C /Users/hans/.platformio/packages/tool-avrdude/avrdude.conf -P usb -c serialupdi -xrtsdtr=high -U flash:w:/Users/hans/.platformio/packages/framework-arduino-megaavr-megacorex/bootloaders/optiboot/bootloaders/mega0/115200/Optiboot_mega0_UART0_DEF_115200_A7.hex:i
avrdude OS error: cannot open port usb: No such file or directory
avrdude error: unable to open programmer serialupdi on port usb

avrdude done.  Thank you.

*** [bootloader] Error 1
```