### PR TITLE
Add AVR32DD14 and AVR32DD20 board definitions

### DIFF
--- a/boards/AVR32DD14.json
+++ b/boards/AVR32DD14.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "dxcore",
+    "extra_flags": "-DARDUINO_AVR_AVR32DD14 -DARDUINO_avrdd -DMUX_DEFAULT_USART1=2 -DMILLIS_USE_TIMER=B1",
+    "f_cpu": "24000000L",
+    "mcu": "avr32dd14",
+    "variant": "14pin-ddseries"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "AVR32DD14",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 32768,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/AVR32DD14",
+  "vendor": "Microchip"
+}

--- a/boards/AVR32DD20.json
+++ b/boards/AVR32DD20.json
@@ -1,0 +1,24 @@
+{
+  "build": {
+    "core": "dxcore",
+    "extra_flags": "-DARDUINO_AVR_AVR32DD20 -DARDUINO_avrdd -DMUX_DEFAULT_USART1=2 -DMILLIS_USE_TIMER=B1",
+    "f_cpu": "24000000L",
+    "mcu": "avr32dd20",
+    "variant": "20pin-ddseries"
+  },
+  "hardware": {
+    "oscillator": "internal"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "AVR32DD20",
+  "upload": {
+    "maximum_ram_size": 4096,
+    "maximum_size": 32768,
+    "protocol": "jtag2updi",
+    "speed": 115200
+  },
+  "url": "https://www.microchip.com/wwwproducts/en/AVR32DD20",
+  "vendor": "Microchip"
+}


### PR DESCRIPTION
Per https://community.platformio.org/t/avr32dd14-support/45906 and #72.

This **needs** to also have additional logic to select a custom toolchain as uploaded by SpeneKonde.

Per <https://drazzy.com/package_drazzy.com_index.json>, we need `7.3.0-atmel3.6.1-azduino6` which are located at
* AARCH64: https://spencekondetoolchains.s3.amazonaws.com/avr-gcc-7.3.0-atmel3.6.1-azduino6-aarch64-pc-linux-gnu.tar.bz2
* ARM32 (probably v6, v7): https://spencekondetoolchains.s3.amazonaws.com/avr-gcc-7.3.0-atmel3.6.1-azduino6-arm-linux-gnueabihf.tar.bz2
* x86 Linux: https://spencekondetoolchains.s3.amazonaws.com/avr-gcc-7.3.0-atmel3.6.1-azduino6-i686-pc-linux-gnu.tar.bz2
* Mac x86_64: https://spencekondetoolchains.s3.amazonaws.com/avr-gcc-7.3.0-atmel3.6.1-azduino6-x86_64-apple-darwin14.tar.bz2
* x64 Linux: https://github.com/SpenceKonde/DxCore/raw/gh-pages/avr-gcc-7.3.0-atmel3.6.1-azduino6-x86_64-pc-linux-gnu.tar.bz2
* Windows 32-bit and 64-bit: https://spencekondetoolchains.s3.amazonaws.com/avr-gcc-7.3.0-atmel3.6.1-azduino6-i686-w64-mingw32.tar.bz2